### PR TITLE
[ETCM-376] Address Book - fix delete

### DIFF
--- a/src/address-book/AddressBook.test.tsx
+++ b/src/address-book/AddressBook.test.tsx
@@ -5,18 +5,21 @@ import userEvent from '@testing-library/user-event'
 import {AddressBook} from './AddressBook'
 import {expectNoValidationErrorOnSubmit, createWithProviders} from '../common/test-helpers'
 
-const VALID_ADDRESS = '0xffffffffffffffffffffffffffffffffffffffff'
+const VALID_ADDRESS_01 = '0x0000000000000000000000000000000000000000'
+const VALID_ADDRESS_02 = '0xffffffffffffffffffffffffffffffffffffffff'
 
 it('can add a new contact', async () => {
   const {queryByText, getByLabelText, getByTestId} = render(<AddressBook />, {
     wrapper: createWithProviders(),
   })
 
+  const modalTitle = 'New Contact'
+
   const newContactButton = getByTestId('add-contact-button')
   userEvent.click(newContactButton)
 
-  // dialog opened
-  await waitFor(() => expect(queryByText('Edit Contact')).toBeInTheDocument())
+  // modal opened
+  await waitFor(() => expect(queryByText(modalTitle)).toBeInTheDocument())
 
   const saveButton = getByTestId('right-button')
   expect(saveButton).toBeDisabled()
@@ -31,7 +34,7 @@ it('can add a new contact', async () => {
   fireEvent.change(addressInput, {target: {value: 'not an address'}})
   await waitFor(() => expect(queryByText(INVALID_ADDRESS_MSG)).toBeInTheDocument())
 
-  fireEvent.change(addressInput, {target: {value: VALID_ADDRESS}})
+  fireEvent.change(addressInput, {target: {value: VALID_ADDRESS_01}})
   await waitFor(() => expect(queryByText(INVALID_ADDRESS_MSG)).not.toBeInTheDocument())
 
   expect(saveButton).toBeDisabled()
@@ -51,12 +54,12 @@ it('can add a new contact', async () => {
   // saving the contact
   await expectNoValidationErrorOnSubmit(queryByText, saveButton)
 
-  // dialog closed
-  await waitFor(() => expect(queryByText('Edit Contact')).not.toBeInTheDocument())
+  // modal closed
+  await waitFor(() => expect(queryByText(modalTitle)).not.toBeInTheDocument())
 
   // new contact shows up
   await waitFor(() => {
-    expect(queryByText(VALID_ADDRESS)).toBeInTheDocument()
+    expect(queryByText(VALID_ADDRESS_01)).toBeInTheDocument()
     expect(queryByText(FINAL_LABEL)).toBeInTheDocument()
   })
 })
@@ -64,15 +67,17 @@ it('can add a new contact', async () => {
 it('can edit a contact', async () => {
   const {queryByText, getByLabelText, getByTestId, getByTitle} = render(<AddressBook />, {
     wrapper: createWithProviders({
-      wallet: {addressBook: {[VALID_ADDRESS]: 'Gandhi'}, accounts: []},
+      wallet: {addressBook: {[VALID_ADDRESS_01]: 'Gandhi'}, accounts: []},
     }),
   })
 
-  const startEditButton = getByTitle('Edit Contact')
+  const modalTitle = 'Edit Contact'
+
+  const startEditButton = getByTitle(modalTitle)
   userEvent.click(startEditButton)
 
-  // dialog opened
-  await waitFor(() => expect(queryByText('Edit Contact')).toBeInTheDocument())
+  // modal opened
+  await waitFor(() => expect(queryByText(modalTitle)).toBeInTheDocument())
 
   const saveButton = getByTestId('right-button')
   expect(saveButton).toBeEnabled()
@@ -85,7 +90,7 @@ it('can edit a contact', async () => {
   expect(addressInput).toBeDisabled()
 
   // address input shows up with the correct value
-  expect(addressInput).toHaveValue(VALID_ADDRESS)
+  expect(addressInput).toHaveValue(VALID_ADDRESS_01)
 
   // label is editable
   const labelInput = getByLabelText('Label')
@@ -100,16 +105,73 @@ it('can edit a contact', async () => {
   // saving the contact
   await expectNoValidationErrorOnSubmit(queryByText, saveButton)
 
-  // dialog closed
-  await waitFor(() => expect(queryByText('Edit Contact')).not.toBeInTheDocument())
+  // modal closed
+  await waitFor(() => expect(queryByText(modalTitle)).not.toBeInTheDocument())
 
   // new contact shows up
   await waitFor(() => {
     // address is the same
-    expect(queryByText(VALID_ADDRESS)).toBeInTheDocument()
+    expect(queryByText(VALID_ADDRESS_01)).toBeInTheDocument()
     // previous label doesn't show up
     expect(queryByText('Gandhi')).not.toBeInTheDocument()
     // new label shows up
     expect(queryByText('Ihdnag')).toBeInTheDocument()
+  })
+})
+
+it('can delete a contact', async () => {
+  const {queryByText, getByTestId, getAllByTitle} = render(<AddressBook />, {
+    wrapper: createWithProviders({
+      wallet: {
+        addressBook: {[VALID_ADDRESS_01]: 'Gandhi', [VALID_ADDRESS_02]: 'Martin'},
+        accounts: [],
+      },
+    }),
+  })
+
+  const modalTitle = 'Delete Contact'
+
+  const expectModalOpenedWithCorrectData = (label: string, address: string) => (): void => {
+    expect(queryByText(modalTitle)).toBeInTheDocument()
+    expect(queryByText('Are you sure you want to delete this contact?')).toBeInTheDocument()
+    expect(queryByText(`${label} (${address})`)).toBeInTheDocument()
+  }
+
+  const expectModalClosed = (): void => expect(queryByText(modalTitle)).not.toBeInTheDocument()
+
+  const startDeleteButtons = getAllByTitle('Delete Contact')
+  const startDeleteButtonGandhi = startDeleteButtons[0]
+  const startDeleteButtonMartin = startDeleteButtons[1]
+
+  // ETCM-376: open modal for Gandhi
+  userEvent.click(startDeleteButtonGandhi)
+  await waitFor(expectModalOpenedWithCorrectData('Gandhi', VALID_ADDRESS_01))
+
+  // cancel deleting Gandhi
+  const cancelButton = getByTestId('left-button')
+  expect(cancelButton).toBeEnabled()
+  userEvent.click(cancelButton)
+  await waitFor(expectModalClosed)
+
+  // check if Martin exists in the address book
+  expect(queryByText('Martin')).toBeInTheDocument()
+  expect(queryByText(VALID_ADDRESS_02)).toBeInTheDocument()
+
+  // open delete modal for Martin
+  userEvent.click(startDeleteButtonMartin)
+  await waitFor(expectModalOpenedWithCorrectData('Martin', VALID_ADDRESS_02))
+
+  // delete Martin
+  const deleteButton = getByTestId('right-button')
+  expect(deleteButton).toBeEnabled()
+  userEvent.click(deleteButton)
+  await waitFor(expectModalClosed)
+
+  // data for Martin is deleted, data for Gandhi is still there
+  await waitFor(() => {
+    expect(queryByText('Gandhi')).toBeInTheDocument()
+    expect(queryByText(VALID_ADDRESS_01)).toBeInTheDocument()
+    expect(queryByText('Martin')).not.toBeInTheDocument()
+    expect(queryByText(VALID_ADDRESS_02)).not.toBeInTheDocument()
   })
 })

--- a/src/translations/en/renderer.json
+++ b/src/translations/en/renderer.json
@@ -233,6 +233,7 @@
       "title": "Address Book",
       "addNew": "Add new",
       "noData": "No saved contacts",
+      "newContact": "New Contact",
       "editContact": "Edit Contact",
       "saveContact": "Save Contact",
       "deleteContact": "Delete Contact",


### PR DESCRIPTION
- The function, `onStartDelete` missed the `setLabel` call, so the delete modal wasn't displaying the correct label
- Added failing tests for the delete flow and fixed the issue. Also made it harder to miss one of the calls.
- The new contact modal showed the title "Edit Contact". Now, it shows either "Edit Contact" or "New Contact" based on the `EditMode`.