### PR TITLE
[ETCM-432] Increase rpc timeouts to accomodate for slower user machines

### DIFF
--- a/src/config/main.ts
+++ b/src/config/main.ts
@@ -188,6 +188,8 @@ const configGetter = convict({
     dataDirName: 'mantis',
     additionalSettings: {
       'mantis.network.rpc.http.cors-allowed-origins': '*',
+      'akka.http.server.request-timeout': '45.seconds',
+      'mantis.async.ask-timeout': '30.seconds',
     },
   }),
 })


### PR DESCRIPTION
It seems that random internal RPC errors visible in UI/console are caused by various timeouts (some of them on IO-heavy components). This PR increases them so node has more time to respond. 