### PR TITLE
Add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+# Describe the bug
+A clear and concise description of what the bug is.
+
+# To Reproduce
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+# Expected behavior
+A clear and concise description of what you expected to happen.
+
+# Desktop (please complete the following information):
+
+- OS: [e.g. Ubuntu 4.15.0-20-generic]
+- Version: [e.g v0.1.0]
+- Configuration: [e.g Mainnet on default configuration]
+
+# Additional context
+Add any other context about the problem here, include screenshots, logs, provide links, propose solution, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Description
+
+_A clear and concise description of what this pull request does or fixes._
+
+# Proposed Solution
+
+_**Optional** Explain how does this PR solves the problem stated in [Description](#Description). You can also enumerate different alternatives considered while approaching this task._
+
+# Important Changes Introduced
+
+_**Optional** Notice Reviewers about changes that were introduced while developing this task_
+
+# Testing
+
+_**Optional** Leave some recommendations should be useful while reviewers are testing this PR_


### PR DESCRIPTION
# Description

We need and standardized way to report issues and propose code changes.

# Proposed Solution

Include `.github/` default templates, mirroring [Mantis](https://github.com/input-output-hk/mantis/tree/v.3.2.1/.github)