### PR TITLE
Fix send TX with non-standard/handcrafted PK

### DIFF
--- a/src/common/util.test.ts
+++ b/src/common/util.test.ts
@@ -12,6 +12,7 @@ import {
   areFundsEnough,
   returnDataToHumanReadable,
   optionHasValue,
+  padPrivateKey,
 } from './util'
 import {asEther} from './units'
 
@@ -119,4 +120,15 @@ it('optionHasValue works correctly', () => {
   assert.equal(optionHasValue(some(2), 1), false)
   assert.equal(optionHasValue(some({foo: {bar: 'wrong'}}), {foo: {bar: 'baz'}}), false)
   assert.equal(optionHasValue(none, 1), false)
+})
+
+it('pads short private key to the correct length', () => {
+  const expectedResult = '0x0000000000000000000000000000000000000000000000000000000123456789'
+  assert.equal(padPrivateKey('0x123456789'), expectedResult)
+  assert.equal(padPrivateKey('123456789'), expectedResult)
+})
+
+it("doesn't change private key with the correct length", () => {
+  const examplePk = '0x8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f'
+  assert.equal(padPrivateKey(examplePk), examplePk)
 })

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -20,6 +20,11 @@ export const toHex = (n: number | BigNumber): string => {
 export const ensure0x = (hexStr: string): string =>
   hexStr.startsWith('0x') ? hexStr : `0x${hexStr}`
 
+export const padPrivateKey = (privateKey: string): string => {
+  const pkWithoutPrefix = privateKey.startsWith('0x') ? privateKey.slice(2) : privateKey
+  return `0x${pkWithoutPrefix.padStart(64, '0')}`
+}
+
 export const isGreater = (minValue = 0) => (b: BigNumber): ValidationResult =>
   !b.isFinite() || !b.isGreaterThan(new BigNumber(minValue))
     ? {tKey: ['common', 'error', 'mustBeANumberGreaterThan'], options: {replace: {minValue}}}

--- a/src/common/wallet-state.ts
+++ b/src/common/wallet-state.ts
@@ -613,6 +613,11 @@ function useWalletState(initialState?: Partial<WalletStateParams>): WalletData {
 
   const getGasPrice = async (): Promise<Wei> => asWei(await web3.eth.getGasPrice())
 
+  const padPrivateKey = (privateKey: string): string => {
+    const pkWithoutPrefix = privateKey.startsWith('0x') ? privateKey.slice(2) : privateKey
+    return `0x${pkWithoutPrefix.padStart(64, '0')}`
+  }
+
   const sendTransaction = async ({
     recipient,
     amount,
@@ -638,7 +643,8 @@ function useWalletState(initialState?: Partial<WalletStateParams>): WalletData {
     }
 
     const privateKey = getCurrentPrivateKey(password)
-    const tx = await web3.eth.accounts.signTransaction(txConfig, privateKey)
+
+    const tx = await web3.eth.accounts.signTransaction(txConfig, padPrivateKey(privateKey))
     if (tx.rawTransaction === undefined) {
       throw createTErrorRenderer(['wallet', 'error', 'couldNotSignTransaction'])
     }

--- a/src/common/wallet-state.ts
+++ b/src/common/wallet-state.ts
@@ -11,7 +11,7 @@ import {createInMemoryStore, Store} from './store'
 import {usePersistedState, useRecurringTimeout} from './hook-utils'
 import {prop} from '../shared/utils'
 import {createTErrorRenderer} from './i18n'
-import {ensure0x, toHex} from './util'
+import {ensure0x, padPrivateKey, toHex} from './util'
 import {asEther, asWei, Wei} from './units'
 import {AccountTransaction, CustomErrors, defaultWeb3, MantisWeb3} from '../web3'
 
@@ -612,11 +612,6 @@ function useWalletState(initialState?: Partial<WalletStateParams>): WalletData {
   const generateAccount = (): Promise<void> => Promise.resolve()
 
   const getGasPrice = async (): Promise<Wei> => asWei(await web3.eth.getGasPrice())
-
-  const padPrivateKey = (privateKey: string): string => {
-    const pkWithoutPrefix = privateKey.startsWith('0x') ? privateKey.slice(2) : privateKey
-    return `0x${pkWithoutPrefix.padStart(64, '0')}`
-  }
 
   const sendTransaction = async ({
     recipient,


### PR DESCRIPTION
# Description

Restoring the wallet from “handcrafted” PK (e.g. `0x123456789`) works, the user can receive funds, but sending a txn fails.
The error: `Expected private key to be an Uint8Array with length 32`

# Proposed Solution

By padding the PK to the correct length (64-digit hexadecimal), send tx works.

# Testing

- On develop: restore a wallet from e.g. `0x123456789` (already has funds on Sagano) and try sending a tx - it will fail with the error message above.
- On this branch: try the same thing, it should work now. 