### PR TITLE
Remove aspect ratio lock

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -61,14 +61,6 @@ if (!app.requestSingleInstanceLock()) {
   app.quit()
 }
 
-function lockAspectRatioOnMacOS(window: BrowserWindow): void {
-  // Lock the aspect ratio to 16:9 so the user can scale,
-  // but not change the height and width independently.
-  // When fullscreen, it's ignored. Works only on macOS.
-  // Win support: https://github.com/electron/electron/pull/18306
-  window.setAspectRatio(ASPECT_RATIO)
-}
-
 function createWindow(t: TFunctionMain): BrowserWindow {
   // Create the browser window.
   const {width, height} = screen.getPrimaryDisplay().workAreaSize
@@ -86,8 +78,6 @@ function createWindow(t: TFunctionMain): BrowserWindow {
   })
 
   Menu.setApplicationMenu(buildMenu(t))
-
-  lockAspectRatioOnMacOS(mainWindow)
 
   const startUrl =
     process.env.ELECTRON_START_URL ||


### PR DESCRIPTION
# Description

The locked aspect ratio was proposed when the new designs were WIP and there were still some text overlap and other responsiveness issues with specific aspect ratios.

Since then I made some improvements to the content layout / sidebar which make this fix obsolete.

Why now?

Previously the aspect ratio lock only worked on macOS.
Support for Windows got merged to electron recently: https://github.com/electron/electron/pull/26941
It's time to decide if we want to go with it or ditch it.

If we leave it in place, it's important to test the aspect lock on Windows when we make the electron upgrade.

# Proposed Solution

Remove aspect ratio lock.

# Testing

Check if there are any issues with reasonable aspect ratios.
