### PR TITLE
[ETCM-513] Make createPersistentStore independent from store stucture

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,6 +112,7 @@ module.exports = {
     // prettier
     'prettier/prettier': 'error',
     // import
+    'import/no-cycle': 'warn',
     'import/order': [
       'error',
       {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "storyshots": "cross-env EXTEND_ESLINT=true react-app-rewired test \"storyshots.*\"",
     "storyshots:update": "yarn storyshots --updateSnapshot && echo -ne '\\007'",
     "lint": "yarn prettier-check && yarn eslint && yarn stylelint && yarn tsc",
-    "eslint": "eslint src bin --ext .js,.ts,.tsx --max-warnings 0",
+    "eslint": "eslint src bin --ext .js,.ts,.tsx --max-warnings 24",
     "stylelint": "stylelint \"**/*.scss\"",
     "prettier-check": "prettier --no-editorconfig --check \"**/*.{js,ts,tsx,scss}\"",
     "prettier": "prettier --no-editorconfig --write \"**/*.{js,ts,tsx,scss}\"",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,57 @@
 import classnames from 'classnames'
 import React from 'react'
+import _ from 'lodash/fp'
 import {SplashScreen} from './SplashScreen'
-import {BackendState} from './common/backend-state'
+import {
+  BackendState,
+  defaultBackendData,
+  migrationsForBackendData,
+  StoreBackendData,
+} from './common/backend-state'
 import {rendererLog} from './common/logger'
-import {createPersistentStore} from './common/store'
-import {WalletState} from './common/wallet-state'
+import {createPersistentStore, Store} from './common/store'
+import {WalletState, defaultWalletData, StoreWalletData} from './common/wallet-state'
 import {config} from './config/renderer'
 import {Router} from './layout/Router'
 import {Sidebar} from './layout/Sidebar'
 import {RouterState} from './router-state'
-import {SettingsState} from './settings-state'
-import {TokensState} from './tokens/tokens-state'
+import {SettingsState, defaultSettingsData, StoreSettingsData} from './settings-state'
+import {TokensState, defaultTokensData, StoreTokensData} from './tokens/tokens-state'
 import {TransactionHistoryService} from './wallets/history'
 import {createWeb3} from './web3'
 import './App.scss'
 
 const web3 = createWeb3(config.rpcAddress)
-const store = createPersistentStore()
+
+// TODO: move migrations and default data related code after restructuring store/state related code
+
+export type StoreData = StoreWalletData & StoreSettingsData & StoreTokensData & StoreBackendData
+
+const defaultData: StoreData = _.mergeAll([
+  defaultWalletData,
+  defaultSettingsData,
+  defaultTokensData,
+  defaultBackendData,
+])
+
+const mergeMigrations = _.mergeAllWith(
+  (
+    objValue: undefined | ((store: Store<StoreData>) => void),
+    srcValue: (store: Store<StoreData>) => void,
+  ) => {
+    if (objValue === undefined) {
+      return srcValue
+    } else {
+      return (store: Store<StoreData>): void => {
+        objValue.call(undefined, store)
+        srcValue.call(undefined, store)
+      }
+    }
+  },
+)
+
+const migrations = mergeMigrations([migrationsForBackendData])
+const store = createPersistentStore({defaults: defaultData, migrations})
 
 const AppContent: React.FC = () => {
   const backendState = BackendState.useContainer()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import './App.scss'
 
 const web3 = createWeb3(config.rpcAddress)
 
-// TODO: move migrations and default data related code after restructuring store/state related code
+// TODO(ETCM-515): move migrations and default data related code after restructuring store/state related code
 
 export type StoreData = StoreWalletData & StoreSettingsData & StoreTokensData & StoreBackendData
 


### PR DESCRIPTION
# Description

_Removed circular dependency where store was dependent on modules(`defaultData` and `migrations`), while modules were dependent on store_

# Proposed Solution

_Makes `createPersistentStore` independent from the store structure itself. `defaultData` and `migrations` are now provided when the instance is created._

# Notes

_There is "utility code" moved to `App.tsx` along with TODO. My plan is to still restructure the store, cause right now it's all around the project. Then this code will be moved to a proper place._

# Testing

_Production build is now working 😉_