### PR TITLE
[ETCM-544] Disable send tx while syncing.

### DIFF
--- a/src/translations/en/renderer.json
+++ b/src/translations/en/renderer.json
@@ -146,7 +146,8 @@
       "removeWalletApproval2": "I understand that all of my wallet data will be deleted from this machine.",
       "noKnownAddresses": "No known addresses",
       "walletIsNotSyncing": "Wallet is not syncing.",
-      "termsAndConditionsApproval": "I accept the terms and conditions."
+      "termsAndConditionsApproval": "I accept the terms and conditions.",
+      "outOfSync": "Wallet is out of sync."
     },
     "feeEstimateLevels": {
       "custom": "Custom",

--- a/src/wallets/TransactionHistory.stories.tsx
+++ b/src/wallets/TransactionHistory.stories.tsx
@@ -23,6 +23,7 @@ import {
 } from './sendTransaction'
 import {wrapWithModal} from '../common/MantisModal'
 import {Transaction} from './history'
+import {mockSyncStatus} from './TransactionHistory.test'
 
 export default {
   title: 'Transaction History',
@@ -37,6 +38,7 @@ export const withNoTransactions = (): JSX.Element => (
     estimateTransactionFee={estimateFeesWithRandomDelay}
     getNextNonce={getNextNonceWithRandomDelay}
     generateAddress={asyncAction('on-generate-address')}
+    syncStatus={mockSyncStatus}
   />
 )
 
@@ -48,6 +50,7 @@ export const withDemoTransactions = (): JSX.Element => (
     estimateTransactionFee={estimateFeesWithRandomDelay}
     getNextNonce={getNextNonceWithRandomDelay}
     generateAddress={asyncAction('on-generate-address')}
+    syncStatus={mockSyncStatus}
   />
 )
 
@@ -121,6 +124,7 @@ export const interactive = (): JSX.Element => {
       estimateTransactionFee={estimateFeesWithRandomDelay}
       getNextNonce={getNextNonceWithRandomDelay}
       generateAddress={asyncAction('on-generate-address')}
+      syncStatus={mockSyncStatus}
     />
   )
 }

--- a/src/wallets/TransactionHistory.test.tsx
+++ b/src/wallets/TransactionHistory.test.tsx
@@ -4,12 +4,22 @@ import {render, RenderResult, waitFor, act, fireEvent} from '@testing-library/re
 import userEvent from '@testing-library/user-event'
 import {some} from 'fp-ts/lib/Option'
 import {TransactionHistory, TransactionHistoryProps} from './TransactionHistory'
-import {Account, FeeEstimates} from '../common/wallet-state'
+import {Account, FeeEstimates, SynchronizationStatusOnline} from '../common/wallet-state'
 import {abbreviateAmountForEnUS, createWithProviders} from '../common/test-helpers'
 import {ADDRESS} from '../storybook-util/dummies'
 import {mockedCopyToClipboard} from '../jest.config'
 import {asWei, asEther, etherValue} from '../common/units'
 import {Transaction} from './history'
+
+export const mockSyncStatus: SynchronizationStatusOnline = {
+  mode: 'online',
+  type: 'blocks',
+  currentBlock: 0,
+  highestKnownBlock: 0,
+  pulledStates: 0,
+  knownStates: 0,
+  lastNewBlockTimestamp: 0,
+}
 
 const tx1: Transaction = {
   hash: '1',
@@ -79,6 +89,7 @@ const defaultProps: TransactionHistoryProps = {
   availableBalance: some(asEther(1234)),
   estimateTransactionFee: estimateFees,
   getNextNonce: getNextNonce,
+  syncStatus: mockSyncStatus,
   generateAddress: jest.fn(),
 }
 
@@ -163,6 +174,11 @@ test('Send modal shows up', async () => {
 
   const {getByTestId, getAllByText, getByText, queryByText} = renderTransactionHistory({
     availableBalance: availableAmount,
+    syncStatus: {
+      mode: 'synced',
+      currentBlock: 0,
+      lastNewBlockTimestamp: 0,
+    },
   })
   const sendButton = getByTestId('send-button')
   await act(async () => userEvent.click(sendButton))

--- a/src/wallets/TransactionHistory.tsx
+++ b/src/wallets/TransactionHistory.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import {Button} from 'antd'
+import {Button, Tooltip} from 'antd'
 import InfiniteScroll from 'react-infinite-scroller'
 import {fold, getOrElse, Option} from 'fp-ts/lib/Option'
 import {pipe} from 'fp-ts/lib/function'
@@ -8,10 +8,30 @@ import {ReceiveTransaction} from './modals/ReceiveTransaction'
 import {SortBy, TransactionList} from './TransactionList'
 import {Trans} from '../common/Trans'
 import {asWei, Wei} from '../common/units'
-import {Account, FeeEstimates} from '../common/wallet-state'
+import {Account, FeeEstimates, SynchronizationStatus} from '../common/wallet-state'
+import {useTranslation} from '../settings-state'
 import {Transaction} from './history'
 
 import './TransactionHistory.scss'
+
+const OUT_OF_SYNC_BLOCKS_THRESHOLD = 5
+
+const ConditionalTooltip = ({
+  title,
+  visible,
+  children,
+}: {
+  title: string
+  visible: boolean
+  children: JSX.Element
+}): JSX.Element =>
+  visible ? (
+    <Tooltip title={title} placement="bottom">
+      {children}
+    </Tooltip>
+  ) : (
+    children
+  )
 
 export interface TransactionHistoryProps {
   transactions: readonly Transaction[]
@@ -20,6 +40,7 @@ export interface TransactionHistoryProps {
   estimateTransactionFee: () => Promise<FeeEstimates>
   getNextNonce: () => Promise<number>
   generateAddress: () => Promise<void>
+  syncStatus: SynchronizationStatus
 }
 
 export const TransactionHistory = ({
@@ -29,7 +50,9 @@ export const TransactionHistory = ({
   getNextNonce,
   generateAddress,
   accounts,
+  syncStatus,
 }: TransactionHistoryProps): JSX.Element => {
+  const {t} = useTranslation()
   const [shownTxNumber, setShownTxNumber] = useState(20)
   const [showSendModal, setShowSendModal] = useState(false)
   const [showReceiveModal, setShowReceiveModal] = useState(false)
@@ -39,7 +62,7 @@ export const TransactionHistory = ({
     direction: 'desc',
   })
 
-  const isSendDisabled = pipe(
+  const isZeroBalance = pipe(
     availableBalance,
     fold(
       () => true,
@@ -47,18 +70,29 @@ export const TransactionHistory = ({
     ),
   )
 
+  const isOutOfSync = !(
+    syncStatus.mode === 'synced' ||
+    (syncStatus.mode === 'online' &&
+      syncStatus.highestKnownBlock - syncStatus.currentBlock < OUT_OF_SYNC_BLOCKS_THRESHOLD)
+  )
+
   return (
     <div className="TransactionHistory">
       <div className="main-buttons">
-        <Button
-          data-testid="send-button"
-          type="primary"
-          className="action left-diagonal"
-          disabled={isSendDisabled}
-          onClick={(): void => setShowSendModal(true)}
-        >
-          <Trans k={['wallet', 'button', 'sendTransaction']} />
-        </Button>
+        <ConditionalTooltip visible={isOutOfSync} title={t(['wallet', 'message', 'outOfSync'])}>
+          <span>
+            <Button
+              data-testid="send-button"
+              type="primary"
+              className="action left-diagonal"
+              disabled={isZeroBalance || isOutOfSync}
+              onClick={(): void => setShowSendModal(true)}
+            >
+              <Trans k={['wallet', 'button', 'sendTransaction']} />
+            </Button>
+          </span>
+        </ConditionalTooltip>
+
         <Button
           data-testid="receive-button"
           type="default"

--- a/src/wallets/Wallet.tsx
+++ b/src/wallets/Wallet.tsx
@@ -13,6 +13,7 @@ const _Wallet = ({
     estimateTransactionFee,
     getNextNonce,
     generateAccount,
+    syncStatus,
   },
 }: PropsWithWalletState<EmptyProps, LoadedState>): JSX.Element => {
   return (
@@ -24,6 +25,7 @@ const _Wallet = ({
         estimateTransactionFee={estimateTransactionFee}
         getNextNonce={getNextNonce}
         generateAddress={generateAccount}
+        syncStatus={syncStatus}
       />
     </div>
   )


### PR DESCRIPTION
# Description

Simply disables send button when sync is in progress. It should be considered that it will disable send button anytime when new blocks being synced which can happen quite often. Not sure whether this is the best UX...maybe we should disable the button only when distance from the top block is big enough?