### PR TITLE
[ETCM-450] Fix confirmations calculation in synced state

### DIFF
--- a/src/wallets/TransactionRow.tsx
+++ b/src/wallets/TransactionRow.tsx
@@ -157,14 +157,16 @@ const Confirmations = ({transaction: {blockNumber}}: TransactionCellProps): JSX.
   if (
     blockNumber === null ||
     walletState.walletStatus !== 'LOADED' ||
-    walletState.syncStatus.mode !== 'online'
+    walletState.syncStatus.mode === 'offline'
   )
     return <></>
 
-  const confirmations = walletState.syncStatus.highestKnownBlock - blockNumber
+  const highestBlock =
+    walletState.syncStatus.mode === 'synced'
+      ? walletState.syncStatus.currentBlock
+      : walletState.syncStatus.highestKnownBlock
+  const confirmations = highestBlock - blockNumber
 
-  // Didn't find exact conditions, but sometimes highest known block is not there?
-  // TODO: ETCM-450
   return Number.isNaN(confirmations) ? (
     <></>
   ) : (


### PR DESCRIPTION
# Description

Properly calculate confirmations number for txns while wallet is in synced state.
