### PR TITLE
[ETCM-478] Add error handler for mantis child process spawn

### DIFF
--- a/src/main/MantisProcess.ts
+++ b/src/main/MantisProcess.ts
@@ -11,10 +11,14 @@ import * as option from 'fp-ts/lib/Option'
 import {pipe} from 'fp-ts/lib/pipeable'
 import * as array from 'fp-ts/lib/Array'
 import _ from 'lodash/fp'
+import {dialog, shell, app} from 'electron'
 import {ElectronLog} from 'electron-log'
 import {setMantisStatus} from './status'
 import {readableToObservable} from './streamUtils'
 import {ClientSettings, MantisConfig, NetworkName} from '../config/type'
+import {TFunctionMain} from './i18n'
+
+const MANTIS_DOCS_URL = 'https://docs.mantisclient.io'
 
 export const isWin = os.platform() === 'win32'
 
@@ -109,6 +113,7 @@ export const MantisProcess = (spawn: typeof childProcess.spawn) => (
   networkName: NetworkName,
   processConfig: MantisConfig,
   mainLog: ElectronLog,
+  t: TFunctionMain,
 ): {spawn: (additionalConfig: ClientSettings) => SpawnedMantisProcess} => {
   const executablePath = processExecutablePath(processConfig)
   const mantisDataDir = resolve(dataDir, networkName)
@@ -136,15 +141,30 @@ export const MantisProcess = (spawn: typeof childProcess.spawn) => (
           processConfig.packageDirectory
         }): ${executablePath} ${settingsAsArguments.join(' ')}`,
       )
-      return new SpawnedMantisProcess(
-        spawn(executablePath, ['mantis', ...settingsAsArguments], {
-          cwd: processConfig.packageDirectory,
-          detached: false,
-          shell: isWin,
-          env: processEnv(processConfig),
-        }) as ChildProcess,
-        mainLog,
-      )
+
+      const process = spawn(executablePath, ['mantis', ...settingsAsArguments], {
+        cwd: processConfig.packageDirectory,
+        detached: false,
+        shell: isWin,
+        env: processEnv(processConfig),
+      })
+
+      process.on('error', async (_) => {
+        const {response} = await dialog.showMessageBox({
+          message: t(['dialog', 'title', 'mantisFailedToStart']),
+          detail: t(['dialog', 'message', 'mantisFailedToStart']),
+          type: 'error',
+          buttons: [t(['dialog', 'button', 'cancel']), t(['dialog', 'button', 'openDocs'])],
+        })
+
+        if (response === 1) {
+          await shell.openExternal(MANTIS_DOCS_URL)
+        }
+
+        app.quit()
+      })
+
+      return new SpawnedMantisProcess(process as ChildProcess, mainLog)
     },
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -254,6 +254,7 @@ walletInit()
           newNetworkName,
           config.mantis,
           mainLog,
+          t,
         )
         const spawnedMantis = mantisProcess.spawn(additionalSettings)
         logMantis(spawnedMantis)

--- a/src/translations/en/main.json
+++ b/src/translations/en/main.json
@@ -9,7 +9,8 @@
       "ok": "OK",
       "saveDebugLogs": "Save Debug logs",
       "selectDirectory": "Select Directory",
-      "selectOtherLocation": "Select other location"
+      "selectOtherLocation": "Select other location",
+      "openDocs": "Open Docs"
     },
     "checkboxLabel": {
       "deleteCurrentDataDir": "Delete my current data directory instead"
@@ -21,13 +22,15 @@
       "incompatibleDataDir": "Your current data directory is incompatible with this version of Mantis Wallet.",
       "incompatibleDataDirAction": "We'll rename your old data directory from \"{{oldDirName}}\" to \"{{newDirName}}\".",
       "deleteDatadirConfirmation": "Are you sure you want to delete \"{{directory}}\"?",
-      "operationComplete": "Operation complete"
+      "operationComplete": "Operation complete",
+      "mantisFailedToStart": "Please check whether you have all prerequisites installed. For more info, see https://docs.mantisclient.io/"
     },
     "title": {
       "incompatibleDataDir": "Incompatible data directory",
       "saveDebugLogs": "Save Debug logs",
       "startupError": "Mantis Wallet startup error",
-      "error": "Error"
+      "error": "Error",
+      "mantisFailedToStart": "Mantis client failed to start!"
     },
     "noVersionTxt": {
       "title": "Unversioned datadir",


### PR DESCRIPTION
# Description

Unhandled error occured when there was no java installed on the system and we tried to run spawn mantis process. I added handler for this case and we now point users to relevant piece of docs.