### PR TITLE
[ETCM-695] Use black as success color in light mode.

### DIFF
--- a/src/themes.scss
+++ b/src/themes.scss
@@ -76,7 +76,7 @@ $themes: (
     secondary-background: $light-secondary-background,
     primary-color: $primary-color,
     secondary-color: $secondary-color,
-    success-color: $primary-color,
+    success-color: $light-text-color,
     tx-success-color: #000,
     success-text: darken($primary-color, 20%),
     error-color: $error-background-color,

--- a/src/wallets/TransactionRow.scss
+++ b/src/wallets/TransactionRow.scss
@@ -133,27 +133,11 @@
     line-height: 14px;
 
     &.incoming {
-      @include themify($themes) {
-        color: themed('success-color');
-      }
+      color: $primary-color;
     }
 
     .fee {
       display: block;
-    }
-  }
-
-  .call-details {
-    .success {
-      @include themify($themes) {
-        color: themed('success-color');
-      }
-    }
-
-    .failure {
-      @include themify($themes) {
-        color: themed('error-text');
-      }
     }
   }
 }

--- a/src/wallets/TransactionRow.tsx
+++ b/src/wallets/TransactionRow.tsx
@@ -181,7 +181,7 @@ export const TxDetailsCell = ({transaction}: TransactionCellProps): JSX.Element 
   const {hash, from, to, gas, gasPrice, gasUsed, contractAddress} = transaction
   return (
     <>
-      <div className="call-details two-col-table">
+      <div className="two-col-table">
         <div>
           <Trans k={['wallet', 'label', 'sendingAddress']} />:
         </div>


### PR DESCRIPTION
# Description

Use black as success color in light mode. Green used before was undistinguishable from the background.

before:

![image](https://user-images.githubusercontent.com/4038239/115530250-e45b1a00-a293-11eb-9338-0ac623e6de07.png)

after:

![image](https://user-images.githubusercontent.com/4038239/115529965-a3fb9c00-a293-11eb-8ef6-0221315cedb3.png)
