### PR TITLE
[ETCM-475] Allow changing from custom network to another custom network.

### DIFF
--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -74,6 +74,9 @@ export const Settings = (): JSX.Element => {
   const [selectedNetwork, setSelectedNetwork] = useState<NetworkName>(networkName)
 
   const changeNetwork = (newNetwork: NetworkName): void => {
+    if (selectedNetwork === newNetwork && isDefinedNetworkName(newNetwork)) {
+      return
+    }
     setSelectedNetwork(newNetwork)
     setActiveModal('ChangeNetwork')
   }
@@ -165,7 +168,7 @@ export const Settings = (): JSX.Element => {
               <Select
                 placeholder="…"
                 value={isDefinedNetworkName(networkName) ? networkName : 'custom'}
-                onChange={changeNetwork}
+                onSelect={changeNetwork}
                 bordered={false}
               >
                 {networkOptions.map(({key, label}) => (


### PR DESCRIPTION
# Description

Allow changing from custom network to another custom network. Previously used method `onChange` was called only when the option in network switcher was different from the current one. However, that way, user could not change from one custom network to another. Hence the method was replaced with `onSelect`, which is called anytime when an option is selected.
