### PR TITLE
[ETCM-860] Hotfix tx history being incomplete

### DIFF
--- a/src/wallets/history/TransactionHistoryService.ts
+++ b/src/wallets/history/TransactionHistoryService.ts
@@ -74,7 +74,7 @@ export class TransactionHistoryService {
     })
 
   static getBestBlockWithWeb3 = (web3: MantisWeb3): Observable<BlockHeader> =>
-    rx.interval(1000).pipe(
+    rx.interval(2000).pipe(
       rxop.concatMap(() => web3.eth.getBlock('latest')),
       rxop.distinctUntilChanged((a, b) => a.hash == b.hash),
       rxop.shareReplay(1),
@@ -93,7 +93,7 @@ export class TransactionHistoryService {
     return new TransactionHistoryService(
       new BehaviorSubject<void>(void 0),
       500,
-      100,
+      500,
       getTransactions,
       storeFactory,
       bestBlock$,
@@ -144,7 +144,7 @@ export class TransactionHistoryService {
       .from(storedHistory.blocksWithKnownTransactions)
       .pipe(
         rxop.mergeMap(
-          (blockToCheck) => this.fetchTransactions(account, blockToCheck, blockToCheck + 1),
+          (blockToCheck) => this.fetchTransactions(account, blockToCheck, blockToCheck),
           5,
         ),
         rxop.reduce<readonly Transaction[]>(uncurry(ArrayOps.concat), []),


### PR DESCRIPTION
# Description

The current implementation of `TransactionHistoryService` works like this:
- it continuously scans 100 blocks behind the best block in the chain
- it discovers tx in 500 blocks of blocks from the start of the chain

The latter happens when best block discovered this way is 500 blocks behind top of the chain. Therefore, there might be some intervals between 100 and 500 blocks from top of the chain, which are not discovered by either of those methods.

This PR is a hotfix, so that 500 blocks are scanned from the top. This will eliminate the issue completely. However, I will create followup task to also properly fix this from technical perspective, so that we can come back to scanning less tx.